### PR TITLE
🧹 [code health improvement] Replace multiple statements separated by …

### DIFF
--- a/Firmware/DASHBOARDpython.txt
+++ b/Firmware/DASHBOARDpython.txt
@@ -345,7 +345,10 @@ class TelemetryApp:
         return self.line_roll, self.line_rate
 
     def reset_dashboard(self):
-        self.time_data.clear(); self.roll_data.clear(); self.rate_data.clear(); self.output_data.clear()
+        self.time_data.clear()
+        self.roll_data.clear()
+        self.rate_data.clear()
+        self.output_data.clear()
         self.mission_events.clear()
         self.current_values = {"Time": 0, "Roll": 0.0, "Rate": 0.0, "Output": 0.0, "State": "DISCONNECTED", "ActiveKp": 0.0, "ActiveKd": 0.0, "Skew": 0.0, "Lat": 0.0, "Lon": 0.0, "Alt": 0.0, "GPS_State": 0}
         self.last_state = "DISCONNECTED"


### PR DESCRIPTION
…semicolon with newlines

In the `reset_dashboard` method of `Firmware/DASHBOARDpython.txt`, multiple `.clear()` calls were on a single line separated by semicolons. These have been split into separate lines for better readability and adherence to standard coding practices.

- 🎯 **What:** Replaced semicolons with newlines in `Firmware/DASHBOARDpython.txt`.
- 💡 **Why:** Improves maintainability and readability by following the convention of one statement per line.
- ✅ **Verification:** Verified syntax correctness with `python3 -m py_compile Firmware/DASHBOARDpython.txt` and performed manual code inspection.
- ✨ **Result:** The code is cleaner and more readable.