### PR TITLE
🔧 Extract launcher WiFi credentials into config.h

### DIFF
--- a/Firmware/config.h
+++ b/Firmware/config.h
@@ -1,0 +1,20 @@
+// ============================================================
+//  config.h — User-specific settings for Launcher Ground Station
+// ============================================================
+//  Edit these values before flashing.
+// ============================================================
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// --- WiFi Access Point ---
+// The launcher creates its own WiFi network (SoftAP mode).
+// The dashboard PC and rocket connect to this network.
+const char* WIFI_SSID     = "ROCKET_LAUNCHER";
+const char* WIFI_PASSWORD = "change_me";
+
+// --- UDP Communication ---
+// Port used for telemetry exchange with the dashboard
+const int UDP_PORT = 4444;
+
+#endif // CONFIG_H

--- a/Firmware/launcher.txt
+++ b/Firmware/launcher.txt
@@ -12,10 +12,8 @@
 #include <QMC5883LCompass.h>
 #include <TinyGPS++.h>
 #include <Adafruit_BMP085.h>
+#include "config.h"
 
-const char* ssid = "ROCKET_LAUNCHER";
-const char* password = "launch_secure"; 
-const int udpPort = 4444;
 WiFiUDP udp;
 IPAddress dashboardIP;
 bool dashboardConnected = false;
@@ -91,11 +89,11 @@ void setup() {
     SerialGPS.begin(9600, SERIAL_8N1, GPS_RX_PIN, -1);
 
     Serial.println("Starting WiFi Access Point...");
-    WiFi.softAP(ssid, password);
+    WiFi.softAP(WIFI_SSID, WIFI_PASSWORD);
     IPAddress IP = WiFi.softAPIP();
     Serial.print("AP IP address: ");
     Serial.println(IP);
-    udp.begin(udpPort);
+    udp.begin(UDP_PORT);
 
     Wire.begin(I2C_SDA, I2C_SCL);
     compass.init();
@@ -154,7 +152,7 @@ void setup() {
 
 void sendToDashboard(String msg) {
     if (dashboardConnected) {
-        udp.beginPacket(dashboardIP, udpPort);
+        udp.beginPacket(dashboardIP, UDP_PORT);
         udp.println(msg);
         udp.endPacket();
     }


### PR DESCRIPTION
```markdown
   ## What this PR does

   Moves hardcoded WiFi SSID, password, and UDP port out of
   launcher.txt into a `config.h` with placeholder values.

   This complements PR #6 (by @giankpetrov) which addresses the
   rocket firmware side. The launcher still had `launch_secure`
   hardcoded.

   ### Changes
   - **`Firmware/config.h`** — new file with `WIFI_SSID`, `WIFI_PASSWORD`, `UDP_PORT`
   - **`Firmware/launcher.txt`** — 5 lines changed to use config.h values

   ### What this does NOT do
   - No logic changes — same SoftAP setup, same UDP port, same behavior
   - Does not conflict with PRs #6, #7, #8 (those touch rocket.txt only)
 ```