### PR TITLE
🔧 Extract dashboard network config into config.py

### DIFF
--- a/Firmware/DASHBOARDpython.txt
+++ b/Firmware/DASHBOARDpython.txt
@@ -8,15 +8,12 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from collections import deque
 import time
 import numpy as np
+from config import UDP_IP, UDP_PORT, LAUNCHER_GATEWAY
 
 # --- Configuration ---
-UDP_IP = "0.0.0.0"  
-UDP_PORT = 4444
 BUFFER_SIZE = 1024
 VIEW_POINTS = 100   
-RATE_SCALE = 0.25   
-
-LAUNCHER_GATEWAY = "192.168.4.1" 
+RATE_SCALE = 0.25
 
 class TelemetryApp:
     def __init__(self, root):

--- a/Firmware/config.py
+++ b/Firmware/config.py
@@ -1,0 +1,17 @@
+# ==============================================================
+#  config.py — User-specific settings for Rocket Telemetry Dashboard
+# ==============================================================
+#  Edit these values to match your launcher's WiFi configuration.
+# ==============================================================
+
+# --- UDP Listener ---
+# IP to bind the listener to (0.0.0.0 = all interfaces)
+UDP_IP = "0.0.0.0"
+
+# UDP port — must match the launcher firmware's UDP_PORT
+UDP_PORT = 4444
+
+# --- Launcher Connection ---
+# The launcher's IP address on its SoftAP network
+# Default is 192.168.4.1 (ESP32 SoftAP default gateway)
+LAUNCHER_GATEWAY = "192.168.4.1"


### PR DESCRIPTION
```markdown
   ## What this PR does

   Moves UDP_IP, UDP_PORT, and LAUNCHER_GATEWAY from DASHBOARDpython.txt
   into a separate `config.py`.

   These are the values users need to match to their launcher's WiFi
   configuration (set in `Firmware/config.h`).

   ### Changes
   - **`Firmware/config.py`** — new file with network settings
   - **`Firmware/DASHBOARDpython.txt`** — imports from config.py instead of inline values
 ```