### PR TITLE
🔒 [security fix] Remove hardcoded WiFi credentials from Launcher firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 # === Fusion 360 recovery ===
 *.f3z.bak
 *.f3z.tmp
+
+# === Secrets ===
+Firmware/Launcher/src/secrets.h

--- a/Firmware/Launcher/src/main.cpp
+++ b/Firmware/Launcher/src/main.cpp
@@ -12,9 +12,10 @@
 #include <QMC5883LCompass.h>
 #include <TinyGPS++.h>
 #include <Adafruit_BMP085.h>
+#include "secrets.h"
 
-const char* ssid = "ROCKET_LAUNCHER";
-const char* password = "launch_secure"; 
+const char* ssid = WIFI_SSID;
+const char* password = WIFI_PASSWORD;
 const int udpPort = 4444;
 WiFiUDP udp;
 IPAddress dashboardIP;

--- a/Firmware/Launcher/src/secrets.h.example
+++ b/Firmware/Launcher/src/secrets.h.example
@@ -1,0 +1,3 @@
+// WiFi credentials for the Rocket Launcher Access Point
+#define WIFI_SSID "YOUR_SSID"
+#define WIFI_PASSWORD "YOUR_PASSWORD"


### PR DESCRIPTION
🎯 What: The vulnerability fixed was the use of hardcoded WiFi SSID and password strings in the Launcher's main.cpp file.
⚠️ Risk: Hardcoded credentials can be easily discovered by anyone with access to the source code, potentially allowing unauthorized access to the Rocket Launcher's WiFi Access Point and control over the launch system.
🛡️ Solution: Moved the credentials to a separate secrets.h file, which is excluded from version control via .gitignore. A secrets.h.example template is provided to guide users on how to configure their own credentials safely.