### PR TITLE
Add GPS targeting system with pitch guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Proof-of-concept guided rocket and launcher prototype using consumer ESP32 microcontrollers, 3D-printed parts, and a Python ground control dashboard. Three cooperating components form the full system.
+
+## Build & Flash (PlatformIO)
+
+Both firmware components are PlatformIO projects under `Firmware/Rocket/` and `Firmware/Launcher/`.
+
+```bash
+# Build and flash the rocket flight computer
+cd Firmware/Rocket
+pio run -e rocket -t upload
+
+# Build and flash the launcher ground station
+cd Firmware/Launcher
+pio run -e launcher -t upload
+
+# Monitor serial output (both projects)
+pio device monitor -b 115200
+```
+
+## Run the Dashboard
+
+```bash
+cd Firmware
+pip install -r requirements.txt          # first time only
+# On Debian/Ubuntu, also: sudo apt install python3-tk
+python dashboard.py
+```
+
+The dashboard connects to the launcher's WiFi AP (`ROCKET_LAUNCHER` / `launch_secure`) at 192.168.4.1 via UDP port 4444.
+
+## System Architecture
+
+### Three-Component Chain
+
+```
+[Python Dashboard] <--UDP 4444--> [Launcher ESP32] <--UART Serial2 115200--> [Rocket ESP32]
+```
+
+**Rocket (`Firmware/Rocket/src/main.cpp`)** — flight computer:
+- Reads MPU6050 (I2C SDA=21, SCL=22) for gyro rate and accelerometer data
+- Runs a PD stabilization loop (`output = Kp*roll + Kd*rate`) at every loop iteration
+- Drives 4 canard servos (GPIO 14/25/26/27) and ignition servo (GPIO 5) via ESP32Servo
+- State machine: `IDLE → ARMED → IGNITING → FLIGHT`
+- Sends `DATA,ax,ay,az,roll,rate,servo_offset,state,Kp,Kd,skew` and `READY` over Serial2
+- Accepts `ARM`, `IGNITE`, `CALIBRATE`, `PID,Kp,Kd` commands from Serial2
+
+**Launcher (`Firmware/Launcher/src/main.cpp`)** — ground station relay:
+- Hosts a WiFi SoftAP and listens for the Python dashboard on UDP 4444
+- State machine: `SAFE → ARMING → READY → IGNITING`; controlled by physical arm switch (GPIO 5) and launch button (GPIO 18)
+- Reads GPS (HardwareSerial1, GPIO 4), QMC5883L compass, and BMP180 barometer over shared I2C (SDA=21, SCL=22)
+- Relays rocket telemetry to the dashboard as `T,...` and `STATUS:...` UDP packets
+- Sends `ENV,lat,lon,alt,gpsState` to dashboard every 1 s
+- Forwards `launch`, `calibrate`, and `PID,...` commands from the dashboard to the rocket via Serial2
+- Blocks at startup if no GPS NMEA data is detected within 5 s
+
+**Dashboard (`Firmware/dashboard.py`)** — ground control UI:
+- Tkinter app with live matplotlib telemetry chart (roll angle + rate, servo output fill)
+- UDP listener thread receives `T,`, `STATUS:`, `ENV,`, and `[FUSION]` messages from the launcher
+- Watchdog thread pings `HELLO` to 192.168.4.1 every 2 s to keep dashboard IP registered
+- Provides CALIBRATE GYRO, DIGITAL LAUNCH, and PID upload buttons
+- GPS status indicator: red=no NMEA, orange=searching, green=fix
+
+### UDP Telemetry Protocol
+
+| Direction | Format | Description |
+|-----------|--------|-------------|
+| Rocket → Dashboard | `T,<ms>,<roll>,<rate>,<servo_out>` | 20 Hz telemetry |
+| Rocket → Dashboard | `STATUS:<state>,<Kp>,<Kd>,<skew>` | State + PID echo |
+| Launcher → Dashboard | `ENV,<lat>,<lon>,<alt>,<gpsState>` | Environment + GPS (1 Hz) |
+| Dashboard → Rocket | `launch` | Triggers ignition |
+| Dashboard → Rocket | `calibrate` | Zeros gyro offset |
+| Dashboard → Rocket | `PID,<Kp>,<Kd>` | Updates PID gains |
+
+### Calibration Files
+
+`Firmware/Calibration & Test Code/` contains standalone `.ino` sketches for:
+- `fin_calibration.ino` — servo center angle tuning
+- `i2c_scanner.ino` — I2C address discovery
+- `roll_stabilization.ino` — isolated stabilization loop testing
+
+These are not part of the PlatformIO build; upload them via Arduino IDE directly.
+
+### Key Constants to Know
+
+Rocket servo center angles (hardcoded, trim via `fin_calibration.ino`):
+- Left: 115°, Right: 80°, Up: 80°, Down: 115°, Max deflection: ±12°
+
+Compass hard-iron calibration offsets in launcher firmware (`MAG_OFFSET_X/Y/Z`, `MAG_SCALE_X/Y/Z`) are hardware-specific and must be re-calibrated if the compass is moved.
+
+> **Note:** Pin assignments in `docs/WIRING.md` were reverse-engineered and may not exactly match the current firmware. Treat the `.cpp` source files as authoritative.

--- a/Firmware/Launcher/src/main.cpp
+++ b/Firmware/Launcher/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * LAUNCHER ESP32 CODE (WiFi AP + Comm Relay + Fusion + GPS + Barometer)
- * V4 - Fully Non-Blocking & GPS Status Tracking
+ * V5 - GPS Targeting: Haversine guidance computation + AIM relay
  */
 
 #include <Arduino.h>
@@ -61,8 +61,47 @@ const float MAG_SCALE_Y = 0.971;
 const float MAG_SCALE_Z = 1.044;
 
 bool udpLaunchTriggered = false;
-bool rocketReady = false; 
-bool rocketIgnited = false; 
+bool rocketReady = false;
+bool rocketIgnited = false;
+
+// --- GPS Targeting ---
+float target_lat           = 0.0;
+float target_lon           = 0.0;
+float target_alt_m         = 0.0;
+bool  target_set           = false;
+float guidance_dist_m      = 0.0;
+float guidance_bearing_deg = 0.0;
+float guidance_elev_deg    = 0.0;
+
+static const float EARTH_R = 6371000.0;
+
+float haversineDistance(float lat1, float lon1, float lat2, float lon2) {
+    float dLat = (lat2 - lat1) * PI / 180.0;
+    float dLon = (lon2 - lon1) * PI / 180.0;
+    float a = sin(dLat * 0.5) * sin(dLat * 0.5) +
+              cos(lat1 * PI / 180.0) * cos(lat2 * PI / 180.0) *
+              sin(dLon * 0.5) * sin(dLon * 0.5);
+    return EARTH_R * 2.0 * atan2(sqrt(a), sqrt(1.0 - a));
+}
+
+float haversineBearing(float lat1, float lon1, float lat2, float lon2) {
+    float dLon = (lon2 - lon1) * PI / 180.0;
+    float y = sin(dLon) * cos(lat2 * PI / 180.0);
+    float x = cos(lat1 * PI / 180.0) * sin(lat2 * PI / 180.0) -
+              sin(lat1 * PI / 180.0) * cos(lat2 * PI / 180.0) * cos(dLon);
+    float b = atan2(y, x) * 180.0 / PI;
+    return b < 0.0 ? b + 360.0 : b;
+}
+
+void computeGuidance() {
+    if (!target_set || !gps.location.isValid() || gps.location.lat() == 0.0) return;
+    float llat = gps.location.lat(), llon = gps.location.lng();
+    guidance_dist_m      = haversineDistance(llat, llon, target_lat, target_lon);
+    guidance_bearing_deg = haversineBearing(llat, llon, target_lat, target_lon);
+    float alt_diff       = target_alt_m - filteredAlt;
+    guidance_elev_deg    = (guidance_dist_m < 1.0) ? 90.0
+                           : atan2(alt_diff, guidance_dist_m) * 180.0 / PI;
+}
 
 void buzzerOn() { digitalWrite(BUZZER_PIN, LOW); }
 void buzzerOff() { digitalWrite(BUZZER_PIN, HIGH); }
@@ -229,7 +268,20 @@ void processUDP() {
         } else if (msg == "calibrate") {
             Serial2.println("CALIBRATE");
         } else if (msg.startsWith("PID,")) {
-            Serial2.println(msg); 
+            Serial2.println(msg);
+        } else if (msg.startsWith("TARGET,")) {
+            int c1 = msg.indexOf(','), c2 = msg.indexOf(',', c1 + 1), c3 = msg.indexOf(',', c2 + 1);
+            if (c1 > 0 && c2 > 0 && c3 > 0) {
+                target_lat   = msg.substring(c1 + 1, c2).toFloat();
+                target_lon   = msg.substring(c2 + 1, c3).toFloat();
+                target_alt_m = msg.substring(c3 + 1).toFloat();
+                target_set   = true;
+                computeGuidance();
+                char buf[96];
+                snprintf(buf, sizeof(buf), "GUIDANCE,%.1f,%.1f,%.1f",
+                         guidance_dist_m, guidance_bearing_deg, guidance_elev_deg);
+                sendToDashboard(String(buf));
+            }
         }
     }
 }
@@ -333,7 +385,13 @@ void loop() {
             if (triggered) {
                 currentState = IGNITING;
                 Serial2.println("CALIBRATE");
-                delay(20);                    
+                delay(20);
+                if (target_set) {
+                    char aimCmd[32];
+                    snprintf(aimCmd, sizeof(aimCmd), "AIM,%.1f", guidance_elev_deg);
+                    Serial2.println(aimCmd);
+                    delay(20);
+                }
                 Serial2.println("IGNITE");
                 Serial.println("IGNITION COMMAND SENT");
             }
@@ -395,6 +453,14 @@ void loop() {
         char envMsg[128];
         snprintf(envMsg, sizeof(envMsg), "ENV,%.6f,%.6f,%.1f,%d", lat, lon, filteredAlt, gpsState);
         sendToDashboard(String(envMsg));
+
+        if (target_set) {
+            computeGuidance();
+            char guidMsg[96];
+            snprintf(guidMsg, sizeof(guidMsg), "GUIDANCE,%.1f,%.1f,%.1f",
+                     guidance_dist_m, guidance_bearing_deg, guidance_elev_deg);
+            sendToDashboard(String(guidMsg));
+        }
     }
 }
 

--- a/Firmware/Rocket/src/main.cpp
+++ b/Firmware/Rocket/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * ROCKET ESP32 CODE (Flight Computer + Stabilization)
- * V4 - Final stable build with Physical Skew Telemetry
+ * V5 - GPS Targeting: pitch PD loop + AIM command
  */
 
 #include <Arduino.h>
@@ -40,28 +40,38 @@ float roll = 0;
 float gyroX_offset = 0;
 float physical_skew_angle = 0.0;
 
+// --- Pitch guidance ---
+float pitch_setpoint_deg = 0.0;
+float pitch_angle        = 0.0;
+float gyroY_offset       = 0.0;
+float Kp_pitch           = 0.3;
+float Kd_pitch           = 0.15;
+
 unsigned long last_time;
 unsigned long lastTelemetrySent = 0;
 unsigned long lastReadySent = 0;
 unsigned long igniteStartTime = 0;
 
 void calibrateGyro() {
-    float sumGyroX = 0, sumAccY = 0, sumAccZ = 0;
+    float sumGyroX = 0, sumGyroY = 0, sumAccY = 0, sumAccZ = 0;
     int samples = 200;
     for (int i = 0; i < samples; i++) {
         sensors_event_t a, g, temp;
         mpu.getEvent(&a, &g, &temp);
         sumGyroX += g.gyro.x;
+        sumGyroY += g.gyro.y;
         sumAccY += a.acceleration.y;
         sumAccZ += a.acceleration.z;
         delay(5);
     }
     gyroX_offset = sumGyroX / samples;
+    gyroY_offset = sumGyroY / samples;
     float avgY = sumAccY / samples;
     float avgZ = sumAccZ / samples;
-    physical_skew_angle = atan2(avgY, avgZ) * 180.0 / PI; 
-    roll = 0.0; 
-    last_time = millis(); 
+    physical_skew_angle = atan2(avgY, avgZ) * 180.0 / PI;
+    roll = 0.0;
+    pitch_angle = 0.0;
+    last_time = millis();
 }
 
 void setup() {
@@ -107,17 +117,28 @@ void loop() {
     float output = (Kp * roll) + (Kd * rate_deg_s);
     int servo_offset = constrain((int)output, -MAX_DEFLECTION, MAX_DEFLECTION);
 
+    // Pitch PD loop — integrates gyro.y to track pitch_setpoint_deg
+    float raw_pitch_rate_rad = g.gyro.y - gyroY_offset;
+    float pitch_rate_deg_s   = raw_pitch_rate_rad * 180.0 / PI;
+    pitch_angle             += pitch_rate_deg_s * dt;
+    float pitch_error  = pitch_setpoint_deg - pitch_angle;
+    float pitch_output = (Kp_pitch * pitch_error) + (Kd_pitch * pitch_rate_deg_s);
+    int   pitch_offset = constrain((int)pitch_output, -MAX_DEFLECTION, MAX_DEFLECTION);
+
     if (sysState == "FLIGHT") {
-        leftServo.write(LEFT_CENTER + servo_offset);
+        // Roll: symmetric across all four canards
+        // Pitch: differential on the vertical (up/down) pair only
+        leftServo.write(LEFT_CENTER  + servo_offset);
         rightServo.write(RIGHT_CENTER + servo_offset);
-        upServo.write(UP_CENTER + servo_offset);
-        downServo.write(DOWN_CENTER + servo_offset);
+        upServo.write(  constrain(UP_CENTER   + servo_offset + pitch_offset, UP_CENTER   - MAX_DEFLECTION, UP_CENTER   + MAX_DEFLECTION));
+        downServo.write(constrain(DOWN_CENTER + servo_offset - pitch_offset, DOWN_CENTER - MAX_DEFLECTION, DOWN_CENTER + MAX_DEFLECTION));
     } else {
         leftServo.write(LEFT_CENTER);
         rightServo.write(RIGHT_CENTER);
         upServo.write(UP_CENTER);
         downServo.write(DOWN_CENTER);
-        servo_offset = 0; 
+        servo_offset = 0;
+        pitch_offset = 0;
     }
 
     if (sysState == "IGNITING" && (current_time - igniteStartTime > 2500)) {
@@ -127,13 +148,14 @@ void loop() {
     }
 
     if (current_time - lastTelemetrySent >= 50) {
-        // Telemetry payload including Skew Angle
-        String payload = "DATA," + String(a.acceleration.x, 2) + "," + 
+        String payload = "DATA," + String(a.acceleration.x, 2) + "," +
                          String(a.acceleration.y, 2) + "," + String(a.acceleration.z, 2) + "," +
-                         String(roll, 2) + "," + String(rate_deg_s, 2) + "," + 
-                         String(servo_offset) + "," + sysState + "," + 
-                         String(Kp, 2) + "," + String(Kd, 2) + "," + 
-                         String(physical_skew_angle, 2);
+                         String(roll, 2) + "," + String(rate_deg_s, 2) + "," +
+                         String(servo_offset) + "," + sysState + "," +
+                         String(Kp, 2) + "," + String(Kd, 2) + "," +
+                         String(physical_skew_angle, 2) + "," +
+                         String(pitch_angle, 2) + "," + String(pitch_setpoint_deg, 2) + "," +
+                         String(pitch_offset);
         Serial2.println(payload);
         lastTelemetrySent = current_time;
     }
@@ -153,6 +175,10 @@ void loop() {
             else if (cmdBuffer.startsWith("PID,")) {
                 int c1 = cmdBuffer.indexOf(','), c2 = cmdBuffer.indexOf(',', c1 + 1);
                 if (c1 > 0 && c2 > 0) { Kp = cmdBuffer.substring(c1 + 1, c2).toFloat(); Kd = cmdBuffer.substring(c2 + 1).toFloat(); }
+            }
+            else if (cmdBuffer.startsWith("AIM,")) {
+                int c1 = cmdBuffer.indexOf(',');
+                if (c1 > 0) pitch_setpoint_deg = cmdBuffer.substring(c1 + 1).toFloat();
             }
             cmdBuffer = ""; 
         } else if (c != '\r') { cmdBuffer += c; }

--- a/Firmware/dashboard.py
+++ b/Firmware/dashboard.py
@@ -33,10 +33,11 @@ class TelemetryApp:
         self.output_data = deque()
         
         self.current_values = {
-            "Time": 0, "Roll": 0.0, "Rate": 0.0, "Output": 0.0, 
+            "Time": 0, "Roll": 0.0, "Rate": 0.0, "Output": 0.0,
             "State": "DISCONNECTED", "ActiveKp": 0.0, "ActiveKd": 0.0,
             "Skew": 0.0,
-            "Lat": 0.0, "Lon": 0.0, "Alt": 0.0, "GPS_State": 0
+            "Lat": 0.0, "Lon": 0.0, "Alt": 0.0, "GPS_State": 0,
+            "GuidDist": 0.0, "GuidBearing": 0.0, "GuidElev": 0.0,
         }
         
         self.mission_events = [] 
@@ -44,6 +45,10 @@ class TelemetryApp:
 
         self.kp_var = tk.StringVar(value="0.5")
         self.kd_var = tk.StringVar(value="0.2")
+
+        self.target_lat_var = tk.StringVar(value="0.000000")
+        self.target_lon_var = tk.StringVar(value="0.000000")
+        self.target_alt_var = tk.StringVar(value="0.0")
 
         self.rocket_ip = None
         self.running = True
@@ -145,6 +150,35 @@ class TelemetryApp:
         self.lbl_active_pid = tk.Label(display_container, text="Kp: --.---  |  Kd: --.---", font=self.fm(13), fg="#004488", bg="white")
         self.lbl_active_pid.pack(side=tk.LEFT)
 
+        # --- GPS TARGETING FRAME ---
+        targeting_frame = ttk.LabelFrame(self.root, text="GPS Targeting", padding=self.s(10))
+        targeting_frame.pack(side=tk.TOP, fill=tk.X, padx=self.s(10), pady=self.s(5))
+
+        entry_frame = ttk.Frame(targeting_frame)
+        entry_frame.pack(side=tk.LEFT, fill=tk.Y, padx=(0, self.s(20)))
+
+        ttk.Label(entry_frame, text="Target Lat:", font=self.f(10)).grid(row=0, column=0, sticky="e", padx=(0, self.s(5)), pady=self.s(2))
+        ttk.Entry(entry_frame, textvariable=self.target_lat_var, width=int(12 * self.ui_scale), font=self.f(10, "bold")).grid(row=0, column=1, sticky="w", pady=self.s(2))
+        ttk.Label(entry_frame, text="Target Lon:", font=self.f(10)).grid(row=1, column=0, sticky="e", padx=(0, self.s(5)), pady=self.s(2))
+        ttk.Entry(entry_frame, textvariable=self.target_lon_var, width=int(12 * self.ui_scale), font=self.f(10, "bold")).grid(row=1, column=1, sticky="w", pady=self.s(2))
+        ttk.Label(entry_frame, text="Target Alt (m):", font=self.f(10)).grid(row=2, column=0, sticky="e", padx=(0, self.s(5)), pady=self.s(2))
+        ttk.Entry(entry_frame, textvariable=self.target_alt_var, width=int(12 * self.ui_scale), font=self.f(10, "bold")).grid(row=2, column=1, sticky="w", pady=self.s(2))
+        ttk.Button(entry_frame, text="SET TARGET", command=self.send_target_command, width=int(14 * self.ui_scale)).grid(row=0, column=2, rowspan=3, sticky="ns", padx=self.s(10), pady=self.s(2))
+
+        ttk.Separator(targeting_frame, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=self.s(15))
+
+        guidance_frame = ttk.Frame(targeting_frame)
+        guidance_frame.pack(side=tk.LEFT, fill=tk.Y, padx=self.s(10))
+        ttk.Label(guidance_frame, text="COMPUTED GUIDANCE:", font=self.f(8, "bold"), foreground="gray").pack(side=tk.TOP, anchor="w")
+        guidance_display = tk.Frame(guidance_frame, bg="black", bd=1, relief=tk.SOLID, padx=self.s(10), pady=self.s(5))
+        guidance_display.pack(side=tk.TOP, anchor="w", pady=(self.s(5), 0))
+        self.lbl_bearing = tk.Label(guidance_display, text="BRG: ---°",  font=self.fm(13), fg="#00FF88", bg="black")
+        self.lbl_bearing.pack(side=tk.LEFT, padx=self.s(8))
+        self.lbl_elev    = tk.Label(guidance_display, text="ELEV: ---°", font=self.fm(13), fg="#00FF88", bg="black")
+        self.lbl_elev.pack(side=tk.LEFT, padx=self.s(8))
+        self.lbl_dist    = tk.Label(guidance_display, text="DIST: --- m", font=self.fm(13), fg="#00FF88", bg="black")
+        self.lbl_dist.pack(side=tk.LEFT, padx=self.s(8))
+
         # --- ENVIRONMENT & LOCATION FRAME ---
         env_frame = ttk.LabelFrame(self.root, text="Environment & Location", padding=self.s(10))
         env_frame.pack(side=tk.TOP, fill=tk.X, padx=self.s(10), pady=self.s(5))
@@ -226,6 +260,25 @@ class TelemetryApp:
         except ValueError:
             messagebox.showerror("Error", "Kp and Kd must be valid numbers.")
 
+    def send_target_command(self):
+        try:
+            lat = float(self.target_lat_var.get())
+            lon = float(self.target_lon_var.get())
+            alt = float(self.target_alt_var.get())
+        except ValueError:
+            messagebox.showerror("Error", "Lat, Lon, and Alt must be valid numbers.")
+            return
+        gps_state = self.current_values.get("GPS_State", 0)
+        if gps_state < 2:
+            if not messagebox.askyesno(
+                "GPS Warning",
+                "Launcher GPS does not have a fix yet.\n"
+                "Guidance cannot be computed without a valid launcher position.\n\n"
+                "Set target anyway?"
+            ):
+                return
+        self._send_udp_command(f"TARGET,{lat:.6f},{lon:.6f},{alt:.1f}")
+
     def connection_watchdog(self):
         while self.running:
             try:
@@ -266,8 +319,15 @@ class TelemetryApp:
                 if len(parts) >= 5: # Safely get the new GPS state variable
                     self.current_values["GPS_State"] = int(parts[4])
 
+            elif message.startswith("GUIDANCE,"):
+                parts = message.split(',')
+                if len(parts) >= 4:
+                    self.current_values["GuidDist"]    = float(parts[1])
+                    self.current_values["GuidBearing"] = float(parts[2])
+                    self.current_values["GuidElev"]    = float(parts[3])
+
             elif message.startswith("T,") or message.startswith("[FUSION]"):
-                if message.startswith("[FUSION]"): return 
+                if message.startswith("[FUSION]"): return
                 parts = message.split(',')
                 if len(parts) >= 5:
                     t, r, rt, o = float(parts[1]), float(parts[2]), float(parts[3]), float(parts[4])
@@ -316,6 +376,17 @@ class TelemetryApp:
                 self.gps_canvas.itemconfig(self.gps_dot, fill="green", outline="green")
                 self.lbl_gps_text.config(text="FIX ACQUIRED", foreground="green")
         
+        if hasattr(self, 'lbl_bearing'):
+            dist = vals.get("GuidDist", 0.0)
+            if dist > 0.0:
+                self.lbl_bearing.config(text=f"BRG: {vals['GuidBearing']:.1f}°")
+                self.lbl_elev.config(   text=f"ELEV: {vals['GuidElev']:.1f}°")
+                self.lbl_dist.config(   text=f"DIST: {dist:.0f} m")
+            else:
+                self.lbl_bearing.config(text="BRG: ---°")
+                self.lbl_elev.config(   text="ELEV: ---°")
+                self.lbl_dist.config(   text="DIST: --- m")
+
         state = vals["State"]
         self.lbl_state_text.config(text=state)
         self.lbl_active_pid.config(text=f"Kp: {vals['ActiveKp']:.3f}  |  Kd: {vals['ActiveKd']:.3f}")
@@ -347,7 +418,7 @@ class TelemetryApp:
     def reset_dashboard(self):
         self.time_data.clear(); self.roll_data.clear(); self.rate_data.clear(); self.output_data.clear()
         self.mission_events.clear()
-        self.current_values = {"Time": 0, "Roll": 0.0, "Rate": 0.0, "Output": 0.0, "State": "DISCONNECTED", "ActiveKp": 0.0, "ActiveKd": 0.0, "Skew": 0.0, "Lat": 0.0, "Lon": 0.0, "Alt": 0.0, "GPS_State": 0}
+        self.current_values = {"Time": 0, "Roll": 0.0, "Rate": 0.0, "Output": 0.0, "State": "DISCONNECTED", "ActiveKp": 0.0, "ActiveKd": 0.0, "Skew": 0.0, "Lat": 0.0, "Lon": 0.0, "Alt": 0.0, "GPS_State": 0, "GuidDist": 0.0, "GuidBearing": 0.0, "GuidElev": 0.0}
         self.last_state = "DISCONNECTED"
         self.update_stats()
 


### PR DESCRIPTION
Adds command-preset guidance across all three components. The launcher computes Haversine bearing and elevation angle from its GPS fix to operator-entered target coordinates, sends AIM,<elev> to the rocket before ignition, and broadcasts GUIDANCE messages to the dashboard. The rocket gains a second PD loop on gyro.y that holds the commanded elevation angle via differential up/down canard deflection. The dashboard gains a GPS Targeting frame with lat/lon/alt entry and a live BRG/ELEV/DIST readout.